### PR TITLE
feat: Infinite scrolling for search pages.

### DIFF
--- a/frontend/App.vue
+++ b/frontend/App.vue
@@ -351,18 +351,22 @@ export default class App extends mixins(Viewer, Nav, PrerenderMixin, RatingRefre
     this.submissionSearch = this.$getList('searchSubmissions', {
       endpoint: '/api/profiles/v1/search/submission/',
       persistent: true,
+      grow: true,
     })
     this.productSearch = this.$getList('searchProducts', {
       endpoint: '/api/sales/v1/search/product/',
       persistent: true,
+      grow: true,
     })
     this.characterSearch = this.$getList('searchCharacters', {
       endpoint: '/api/profiles/v1/search/character/',
       persistent: true,
+      grow: true,
     })
     this.profileSearch = this.$getList('searchProfiles', {
       endpoint: '/api/profiles/v1/search/user/',
       persistent: true,
+      grow: true,
     })
   }
 

--- a/frontend/components/AcGrowSpinner.vue
+++ b/frontend/components/AcGrowSpinner.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-col v-observe-visibility="grower">
+  <v-col v-observe-visibility="{callback: grower, intersection: {rootMargin}}">
     <ac-loading-spinner :min-height="minHeight" v-if="list.fetching && list.currentPage > 1" />
   </v-col>
 </template>
@@ -34,6 +34,10 @@ export default class AcGrowSpinner extends Vue {
       if (val) {
         this.list.grower(this.visible)
       }
+    }
+
+    public get rootMargin() {
+      return `0px 0px ${window.innerHeight * 1.5}px 0px`
     }
 
     public grower(val: boolean) {

--- a/frontend/components/views/search/Search.vue
+++ b/frontend/components/views/search/Search.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container v-if="searchForm">
-    <v-row no-gutters  >
+    <v-row no-gutters  v-observe-visibility="(val) => {showUp = !val}">
       <v-col cols="12" sm="6" md="3" lg="4" order="1" order-sm="1">
         <ac-bound-field :field="searchForm.fields.q" label="I'm looking for..." :autofocus="true" />
       </v-col>
@@ -37,6 +37,7 @@
         </v-col>
       </v-col>
     </v-row>
+    <v-btn color="primary" fab bottom right fixed v-if="showUp" @click="scrollUp"><v-icon>arrow_upward</v-icon></v-btn>
     <router-view name="extra" />
     <router-view class="pt-3" />
   </v-container>
@@ -52,6 +53,11 @@ import AcBoundField from '@/components/fields/AcBoundField'
   })
 export default class Search extends mixins(Viewer) {
     public searchForm: FormController = null as unknown as FormController
+    public showUp = false
+
+    public scrollUp() {
+      window.scrollTo(0, 0)
+    }
 
     public created() {
       this.searchForm = this.$getForm('search')

--- a/frontend/components/views/search/SearchCharacters.vue
+++ b/frontend/components/views/search/SearchCharacters.vue
@@ -1,5 +1,5 @@
 <template>
-  <ac-paginated :list="list" :track-pages="true" :auto-run="false">
+  <ac-paginated :list="list" :auto-run="false" :show-pagination="false">
     <template v-slot:default>
       <v-col class="pa-2" sm="6" md="4" lg="3" xl="2" v-for="character in list.list" :key="character.x.id">
         <ac-character-preview :character="character.x"></ac-character-preview>
@@ -30,6 +30,7 @@ export default class SearchCharacters extends mixins(SearchList) {
       this.list = this.$getList('searchCharacters', {
         endpoint: '/api/profiles/v1/search/character/',
         persistent: true,
+        grow: true,
       })
     }
 }

--- a/frontend/components/views/search/SearchProducts.vue
+++ b/frontend/components/views/search/SearchProducts.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container fluid class="pa-0">
-    <ac-paginated :list="list" :track-pages="true" :auto-run="false">
+    <ac-paginated :list="list" :auto-run="false" :show-pagination="false">
       <template v-slot:default>
         <v-col class="pa-1" cols="6" md="4" lg="3" xl="2" v-for="product in list.list" :key="product.x.id">
           <ac-product-preview :product="product.x" />
@@ -30,7 +30,9 @@ export default class SearchProducts extends mixins(SearchList) {
     public list: ListController<Product> = null as unknown as ListController<Product>
     public created() {
       this.list = this.$getList('searchProducts', {
-        endpoint: '/api/sales/v1/search/product/', persistent: true,
+        endpoint: '/api/sales/v1/search/product/',
+        persistent: true,
+        grow: true,
       })
       this.rawUpdate(this.searchForm.rawData)
     }

--- a/frontend/components/views/search/SearchProfiles.vue
+++ b/frontend/components/views/search/SearchProfiles.vue
@@ -1,5 +1,5 @@
 <template>
-  <ac-paginated :list="list" :track-pages="true" :auto-run="false">
+  <ac-paginated :list="list" :auto-run="false" :show-pagination="false">
     <v-col cols="4" sm="3" md="2" lg="1" v-for="user in list.list" :key="user.x.id">
       <ac-avatar :user="user.x"></ac-avatar>
     </v-col>
@@ -21,6 +21,7 @@ export default class SearchProfiles extends mixins(SearchList) {
       this.list = this.$getList('searchProfiles', {
         endpoint: '/api/profiles/v1/search/user/',
         persistent: true,
+        grow: true,
       })
     }
 }

--- a/frontend/components/views/search/SearchSubmissions.vue
+++ b/frontend/components/views/search/SearchSubmissions.vue
@@ -1,5 +1,5 @@
 <template>
-  <ac-paginated :list="list" :track-pages="true" :auto-run="false">
+  <ac-paginated :list="list" :auto-run="false" :show-pagination="false">
     <v-row no-gutters>
       <v-col cols="4" sm="3" lg="2" v-for="submission in list.list" :key="submission.x.id">
         <ac-gallery-preview :submission="submission.x" :show-footer="false" />
@@ -33,6 +33,7 @@ export default class SearchSubmissions extends mixins(SearchList) {
       this.list = this.$getList('searchSubmissions', {
         endpoint: '/api/profiles/v1/search/submission/',
         persistent: true,
+        grow: true,
       })
     }
 }

--- a/frontend/specs/helpers/index.ts
+++ b/frontend/specs/helpers/index.ts
@@ -35,6 +35,7 @@ import {HttpVerbs} from '@/store/forms/types/HttpVerbs'
 import {Shortcuts} from '@/plugins/shortcuts'
 import {VueSocket} from '@/plugins/socket'
 import WS from 'jest-websocket-mock'
+import VueObserveVisibility from 'vue-observe-visibility'
 
 export interface ExtraData {
   status?: number,
@@ -161,6 +162,7 @@ export function vueSetup() {
   localVue.use(FormControllers)
   localVue.use(Characters)
   localVue.use(Shortcuts)
+  localVue.use(VueObserveVisibility)
   vuetifySetup()
   // We won't use the Router in all tests, but we always have these modifications when we do.
   // @ts-ignore

--- a/frontend/specs/setupTestEnv.ts
+++ b/frontend/specs/setupTestEnv.ts
@@ -32,7 +32,23 @@ export class LocalStorageMock {
     }
 }
 
+export class IntersectionObserverMock {
+  callback: any
+  options: any
+  observe: any
+  unobserve: any
+  disconnect: any
+  constructor(callback: any, options: any) {
+    this.callback = callback
+    this.options = options
+    this.observe = jest.fn()
+    this.unobserve = jest.fn()
+    this.disconnect = jest.fn()
+  }
+}
+
 Object.defineProperty(window, 'localStorage', {value: new LocalStorageMock()})
+Object.defineProperty(window, 'IntersectionObserver', {value: IntersectionObserverMock})
 
 // @ts-ignore
 window.ResizeObserver = window.ResizeObserver || jest.fn().mockImplementation(() => ({

--- a/package-lock.json
+++ b/package-lock.json
@@ -14139,9 +14139,9 @@
       }
     },
     "vue-observe-visibility": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/vue-observe-visibility/-/vue-observe-visibility-0.4.6.tgz",
-      "integrity": "sha512-xo0CEVdkjSjhJoDdLSvoZoQrw/H2BlzB5jrCBKGZNXN2zdZgMuZ9BKrxXDjNP2AxlcCoKc8OahI3F3r3JGLv2Q=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vue-observe-visibility/-/vue-observe-visibility-1.0.0.tgz",
+      "integrity": "sha512-s5TFh3s3h3Mhd3jaz3zGzkVHKHnc/0C/gNr30olO99+yw2hl3WBhK3ng3/f9OF+qkW4+l7GkmwfAzDAcY3lCFg=="
     },
     "vue-property-decorator": {
       "version": "8.5.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "vue-class-component": "^7.2.6",
     "vue-focus": "^2.1.0",
     "vue-frag": "^1.4.0",
-    "vue-observe-visibility": "^0.4.6",
+    "vue-observe-visibility": "^1.0.0",
     "vue-property-decorator": "^8.5.1",
     "vue-recaptcha": "^1.3.0",
     "vue-router": "3.5.3",


### PR DESCRIPTION
## Description

This PR adds infinite scrolling capabilities to the search pages. This allows for much easier browsing of content and products and better matches expectations in modern UX.

## Testing instructions

1. Create a bunch of products, submissions, and characters
2. Scroll down and watch them load before you get there.
3. The images should load before you scroll them all the way into view (unless you're going really really fast) **Not yet working**
4. Going back after visiting a product/submission should not take a long time to load **Not yet working**
