### PR TITLE
ToS Updates re: AI Content and Tagging

### DIFF
--- a/frontend/components/views/faq/Other.vue
+++ b/frontend/components/views/faq/Other.vue
@@ -66,15 +66,17 @@
         <strong>What is your content policy?</strong>
       </v-expansion-panel-header>
       <v-expansion-panel-content>
-        In general, the policy is 'nothing illegal.' We don't believe in telling you what you can and can't draw. The
-        requirement we have is that content must be properly tagged, especially NSFW content. If users cannot
-        <router-link :to="{name: 'Other', params: {question: 'blacklist'}}">blacklist</router-link>
-        your content by tag (and by
-        <router-link :to="{name: 'Other', params: {question: 'content-ratings'}}">rating</router-link>
-        as applicable) your account may be subject to disciplinary action.
-
-        There is some content which is legal but which is also not permitted:
-
+        <p>
+          In general, the policy is 'nothing illegal.' We don't believe in telling you what you can and can't draw. The
+          requirement we have is that content must be properly tagged, especially NSFW content. If users cannot
+          <router-link :to="{name: 'Other', params: {question: 'blacklist'}}">blacklist</router-link>
+          your content by tag (and by
+          <router-link :to="{name: 'Other', params: {question: 'content-ratings'}}">rating</router-link>
+          as applicable) your account may be subject to disciplinary action.
+        </p>
+        <p>
+          There is some content which is legal but which is also not permitted:
+        </p>
         <ul>
           <li>Explicit photos of humans</li>
           <li>Photographs of humans uploaded without consent</li>
@@ -97,6 +99,89 @@
         This is not an exhaustive list. If you are unsure if your content is illegal, please consult with your
         attorney. You may also check our <router-link :to="{name: 'TermsOfService'}">Terms of Service</router-link>
         for more information.
+      </v-expansion-panel-content>
+    </v-expansion-panel>
+    <v-expansion-panel>
+      <v-expansion-panel-header>
+        <strong>What is your tagging policy?</strong>
+      </v-expansion-panel-header>
+      <v-expansion-panel-content>
+        <p>Artconomy has
+          <router-link :to="{name: 'Other', params: {question: 'content-policy'}}">very few restrictions</router-link>
+          on what content may be posted, but with this freedom comes a responsibility to tag content effectively.
+          Tagging content serves the following purposes:
+        </p>
+        <ul>
+          <li>It makes products, submissions, and characters easy for visitors to find via search. Customers interested
+            in your content may not be able to find it if it is not properly tagged.</li>
+          <li>It makes such content easy to <router-link :to="{name: 'Other', params: {}}">blacklist</router-link> for
+            those who do not wish to see it.</li>
+        </ul>
+        <p>
+          In sum, tagging allows viewers of the site to have control over their experience, and tagging allows artists
+          to find their audience. This, in combination with
+          <router-link :to="{name: 'Other', params: {question: 'content-policy'}}">content ratings</router-link>
+          allows Artconomy to serve a wide, often disparate range of content without telling artists what they may or
+          may not create.
+        </p>
+        <p>These purposes guide tagging-- which means that
+          <strong>appearances are more important than lore-based truth</strong> for content. This is commonly referred
+          to as a <strong>tag what you see</strong> policy. Tag what you see is the first priority, but you may also
+          tag for lore accuracy when it's in conflict with what's visible 'in frame' for a piece.</p>
+        <p>
+          At the time of writing, minimum tag requirements are not technically enforced, but will be eventually.
+          However, even with a minimum number of tags, it is not always clear what kind of content warrants tagging,
+          or how to go about it. We therefore offer the following guidelines:
+        </p>
+        <ul>
+          <li>
+            Always seek to use existing tags rather than creating new ones. If one does not exist for the thing you are
+            tagging, only then should you create one.
+          </li>
+          <li>
+            Character species should always be tagged. If a species is not a real-world species, but based on a
+            real-world species, it is recommended to at least tag the real-world species, and preferably the name of the
+            fantasy species as well. For example, a 'human' tag is best applied to drawings featuring elves, because
+            even though elves are not human, they are substantially based upon them. In such cases the 'human' tag
+            should be applied, and preferably 'elf' as well.
+          </li>
+          <li>
+            Apparent character sex should always be tagged-- if actual sex is different from apparent sex, that should
+            be tagged as well. You are encouraged to tag a character's gender. If a character is sexless and/or
+            genderless, you should tag to this effect.
+          </li>
+          <li>
+            Kinks depicted in a piece must be tagged, as should any body parts that are the focus of a piece, or any
+            fetish gear/accessories featured in a piece.
+          </li>
+          <li>
+            If a piece is within a specific genre or style, that should be tagged. Examples include 'furry', 'anime',
+            'manga', 'cubism', etc.
+          </li>
+          <li>
+            If a piece utilizes a specific technique or discipline, that should be tagged. Examples include
+            'lines', 'watercolor', 'traditional', 'digital', 'sketch', 'origami', etc.
+          </li>
+          <li>
+            If an automated tool significantly contributes to the creation of a piece, that tool and its general
+            category must be tagged. Examples include 'AI Assisted', 'AI Generated', 'Stable Diffusion', etc.
+          </li>
+        </ul>
+        <p>
+          Tagging is an art in and of itself. We have expectation that users provide a best effort at tagging. To help
+          keep tag quality high, some pages allow for all users to contribute and modify tags. If you see a submission
+          which is not tagged properly, you are encouraged to tag it. If users are tagging your work inappropriately,
+          you may disable public tagging in your
+          <router-link
+              :to="{name: 'Settings', params: {username: viewer.username, tabName: 'options'}}"
+              v-if="isRegistered"
+          >
+            settings</router-link><span v-else>settings</span>.
+        </p>
+        <p>
+          Users who repeatedly fail to observe tagging guidelines, especially those who do not tag content that is
+          considered extreme or offensive by most viewers, will have their account subject to disciplinary action.
+        </p>
       </v-expansion-panel-content>
     </v-expansion-panel>
     <v-expansion-panel>
@@ -236,7 +321,7 @@ import {paramHandleArray} from '@/lib/lib'
 import QuestionSet from '@/components/views/faq/mixins/question-set'
 
 const other = [
-  'content-ratings', 'content-policy', 'blacklist', 'watching', 'blocking', 'file-formats',
+  'content-ratings', 'content-policy', 'tagging', 'blacklist', 'watching', 'blocking', 'file-formats',
 ]
   @Component
 export default class Other extends mixins(Viewer, QuestionSet) {

--- a/frontend/components/views/legal/TermsOfService.vue
+++ b/frontend/components/views/legal/TermsOfService.vue
@@ -11,7 +11,7 @@
         </div>
       </v-col>
       <v-col cols="12">
-        <p><strong>Last updated: December 16, 2022</strong></p>
+        <p><strong>Last updated: December 31, 2022</strong></p>
 
         <p>Please read these Terms of Service ("Terms", "Terms of Service") carefully before using
           the https://artconomy.com/ website (the "Service") operated by

--- a/frontend/components/views/legal/TermsOfService.vue
+++ b/frontend/components/views/legal/TermsOfService.vue
@@ -11,7 +11,7 @@
         </div>
       </v-col>
       <v-col cols="12">
-        <p><strong>Last updated: November 29, 2019</strong></p>
+        <p><strong>Last updated: December 16, 2022</strong></p>
 
         <p>Please read these Terms of Service ("Terms", "Terms of Service") carefully before using
           the https://artconomy.com/ website (the "Service") operated by
@@ -174,9 +174,41 @@
           law enforcement if it deems necessary.
         </p>
 
-        <h2>Bank Transfers</h2>
-        <p>You expressly authorize Artconomy's service provider, Dwolla, Inc. to originate credit transfers
-          to your financial institution account.</p>
+        <h3>Scope, Intent, and Responsibilities</h3>
+
+        <p>
+          Artconomy's purpose is to provide a marketplace and set of tools to improve the business viability of artists
+          creating custom commission work. As a marketplace, it intends also to connect commissioners with artists.
+          In order to provide this service, users are expected to observe the following:
+        </p>
+
+        <ul>
+          <li>
+            Users offering products for sale of art created by another entity must include that entity's trade name
+            in the relevant product descriptions. This includes human artists, artist collectives, and AI programs which
+            contribute substantially to the final products being delivered.
+          </li>
+          <li>
+            Users are expected to make a best effort to rate and tag content according to the content ratings as
+            described on the relevant FAQ pages. These pages are available at
+            <a href="https://artconomy.com/faq/other/content-ratings">https://artconomy.com/faq/other/content-ratings</a>
+            and
+            <a href="https://artconomy.com/faq/other/tagging">https://artconomy.com/faq/other/tagging</a>.
+          </li>
+          <li>
+            Galleries are intended for the purposes of showcasing the capabilities
+            of artists offering their work, and for showcasing work that users have received from artists. Galleries
+            may not be in conflict with this purpose, nor exhaust resources unreasonably.
+            Examples of galleries in conflict with these principle include unreasonably large galleries, or galleries
+            substantially filled by AI generated content beyond what is needed to demonstrate applicability as a
+            product example or character reference.
+          </li>
+        </ul>
+
+        <p>
+          Accounts in violation of these principles may be subject to disciplinary action,
+          including account suspension and closure.
+        </p>
 
         <h2>Arbitration</h2>
         <p>


### PR DESCRIPTION
This PR includes a set of Terms of Service updates to reflect changes in the market and usage, especially regarding tagging and use of AI.

The changes are based on the following principles:

1. Tagging is important, and as more and more content is uploaded, it's becoming more common for insufficiently tagged content to cause problems for people who want to blacklist it. These changes confer clearer expectations around tagging, and addresses an actual issue that is happening.
2. AI is a genie out of the bottle. The goal is not to stop it, which is impossible, but to make sure its scope of use makes sense within our community-- namely by prohibiting spam usage, and requiring labeling. This is an attempt to address anticipated issues in a minimally disruptive way.

One note to make here is that while we COULD make a prohibition on AI-based art products being sold, this seems unnecessary to me because:

1. So-called 'prompt engineers' will soon be obviated by better prompt parsing. If someone wants to generate AI art, they'll be able to do so directly rather than using a middle-man, so I don't see much point in writing in a prohibition. The market will be laughably short-lived or else narrow enough to be constrained by other means than we need to explicitly ban. It'd be like being a 'professional Googler'. That isn't a real job, even if us programmers joke that's what we are. :)
2. It's likely that AI will be integrated somewhere in the toolchain of many artists. 'Content-aware fill' is arguably already an AI-based product that's been around for years acting as an aid for artists. To ban AI outright would preclude these tools, in whatever form they take, from being used.
3. For those who find AI art to be especially disturbing or distasteful, this requirement to tag it should aid in blacklisting. I even specify in the docs which tags to use so there's no confusion on how to tag and blacklist this case.

It's worth noting that, at this time, I've not seen any users offering AI products. I'm not even sure any AI-assisted/generated art has been uploaded. These rules are tailored to prevent cases that AI art makes most egregious (spamming, misrepresentation of what's being offered) while giving room for artists to use them in a serious manner.

We've not had to make a significant ToS change for a few years, so I wanted to put this up as a pull request and get community feedback before pulling the trigger on it.