### PR TITLE
Legal: Terms of service and refund policy updates for April 1, 2023

### DIFF
--- a/frontend/components/views/legal/RefundPolicy.vue
+++ b/frontend/components/views/legal/RefundPolicy.vue
@@ -57,6 +57,15 @@
           Artconomy subscription services may be refunded if a refund is requested within three business days of
           purchase or renewal.
         </p>
+        <p>
+          If a subscription service changes its features or pricing relevant to your activity (such as fees on
+          transactions) during your current billing cycle, or within three days of a billing cycle, you may cancel your
+          subscription service and receive a refund for any monthly dues for that period. Any usage fees incurred during
+          that period will either be removed or adjusted to their previous values for the cycle, at the
+          discretion of Artconomy. For the purposes of this clause, a billing cycle will be considered monthly, even if
+          the client has agreed to a longer cycle. Cancellation of service in these cases will result in
+          prorated refunds for the remaining time.
+        </p>
         <h2>Refund Fees</h2>
         <p>
           As Artconomy does not control the refund policy of artists on the platform, Artconomy will always be entitled
@@ -66,8 +75,9 @@
           No fees are required for refunding of Artconomy Subscription services.
         </p>
         <p>
-          Artconomy does not collect fees on commissions not covered by Artconomy Shield, but fees may be assessed
-          according to the terms of any payment processor the commissioner and artist agree to use.
+          Artconomy does not collect fees from commissioners on commissions not covered by Artconomy Shield, but fees
+          may be assessed according to the terms of any payment processor the commissioner and artist agree to use.
+          Artconomy does not offer any refunds for non-shield commissions.
         </p>
       </v-col>
     </v-row>

--- a/frontend/components/views/legal/RefundPolicy.vue
+++ b/frontend/components/views/legal/RefundPolicy.vue
@@ -11,7 +11,7 @@
         </div>
       </v-col>
       <v-col cols="12">
-        <p><strong>Last updated: November 29, 2019</strong></p>
+        <p><strong>Last updated: April 1, 2023</strong></p>
         <p>
           Artconomy endeavors to satisfy all of its customers of any issues they have with products purchased through
           our platform. However, due to the nature of services rendered, this is not always possible. This document lays

--- a/frontend/components/views/legal/TermsOfService.vue
+++ b/frontend/components/views/legal/TermsOfService.vue
@@ -11,7 +11,7 @@
         </div>
       </v-col>
       <v-col cols="12">
-        <p><strong>Last updated: December 31, 2022</strong></p>
+        <p><strong>Last updated: April 1, 2023</strong></p>
 
         <p>Please read these Terms of Service ("Terms", "Terms of Service") carefully before using
           the https://artconomy.com/ website (the "Service") operated by

--- a/frontend/components/views/legal/TermsOfService.vue
+++ b/frontend/components/views/legal/TermsOfService.vue
@@ -114,10 +114,10 @@
           assigns damages as a result of a dispute arising from the sale.</p>
 
         <p>
-          Subscription services will provide features such as notification of artist availability, but will not be
-          warranted for any particular use, and are provided AS IS. No guarantee is given that artists will accept
-          orders placed by subscription holders, or that artists will be timely in their workload management or
-          responses to subscription holders. Each Artist is responsible for their own performance.
+          Subscription services will be billed monthly, or at another explicitly agreed upon interval. The specific
+          features of subscription tiers are subject to change without notice. You agree that your subscription may be
+          terminated, and your account limited or suspended for failure to pay any fees associated with your
+          subscription.
         </p>
 
         <p>Refunds are covered by our
@@ -225,9 +225,15 @@
           be made after two years from when the aggrieved party knew or should have
           known of the controversy, claim, dispute or breach.
         </p>
-
+        <p>
+          Prevailing party means the party in whose favor final judgment after appeal (if any) is rendered with
+          respect to the claims asserted in the Complaint. "Reasonable attorneys' fees" are those reasonable attorneys'
+          fees actually incurred in obtaining a judgment in favor of the prevailing party.
+        </p>
+        <p>
+          The prevailing party will be entitled to Reasonable attorneys' fees.
+        </p>
         <h2>Contact Us</h2>
-
         <p>If you have any questions about these Terms, please contact us at info@artconomy.com.</p>
       </v-col>
     </v-row>


### PR DESCRIPTION
## Description

This pull request contains terms of service/refund policy changes to be enacted on April 1st, 2023. These changes clarify expectations around subscription payments, refunds, and arbitration.

Despite the date of intended enactment's reputation for jocularity-- no joke is intended here. I'll be commenting on each change in this PR to expand upon it.

These changes exist primarily to support the changes in [this pull request](https://github.com/Kelketek/artconomy/pull/19), which significantly changes how features work.