### PR TITLE
Update Terms of Service and Commission Agreement

### DIFF
--- a/frontend/components/views/legal/CommissionAgreement.vue
+++ b/frontend/components/views/legal/CommissionAgreement.vue
@@ -11,8 +11,7 @@
         </div>
       </v-col>
       <v-col cols="12">
-        <p><strong>Last updated: November 29, 2019</strong>
-        </p>
+        <p><strong>Last updated: March 29, 2024</strong></p>
         <p>
           This is an agreement ("Agreement") between the commissioner (“Commissioner”), artist (“Artist”), and the
           intermediary (“Artconomy”) to complete an artistic work ("Commission").
@@ -109,6 +108,14 @@
           unless it has been uploaded to their public gallery, in which case it may be used within screenshots of the
           service or when posting examples of what work has been commissioned through Artconomy.
         </p>
+        <p>
+          In the event that rights assignment is limited by law, such as inalienable authors rights in Germany, the
+          Artist shall inform the Commissioner of these limitations in the Commission Info settings of their account,
+          which is copied and appended to every commission agreement. To the extent possible by law, the Author affirms
+          intent to assign or grant rights as intended in this agreement, and any assignment or grant deemed invalid
+          will not invalidate any other assignment or grant. Rights will be assigned in the regimes of the Commissioner,
+          the Artist, and Artconomy per the Governing Law section.
+        </p>
         <h2>Arbitration</h2>
         <p>
           Any controversy or claim arising out of or relating to this contract, or the breach thereof, shall be settled
@@ -141,16 +148,10 @@
   </v-container>
 </template>
 
-<script lang="ts">
-import {Component, toNative, Vue} from 'vue-facing-decorator'
+<script setup lang="ts">
 import {BASE_URL} from '@/lib/lib.ts'
 
-@Component
-class CommissionAgreement extends Vue {
-  public logo = new URL('/static/images/logo.svg', BASE_URL).href
-}
-
-export default toNative(CommissionAgreement)
+const logo = new URL('/static/images/logo.svg', BASE_URL).href
 </script>
 
 <style scoped>

--- a/frontend/components/views/legal/Policies.vue
+++ b/frontend/components/views/legal/Policies.vue
@@ -55,12 +55,5 @@
   </v-container>
 </template>
 
-<script lang="ts">
-import {Component, toNative, Vue} from 'vue-facing-decorator'
-
-@Component
-class Policies extends Vue {
-}
-
-export default toNative(Policies)
+<script setup lang="ts">
 </script>

--- a/frontend/components/views/legal/PrivacyPolicy.vue
+++ b/frontend/components/views/legal/PrivacyPolicy.vue
@@ -157,16 +157,10 @@
   </v-container>
 </template>
 
-<script lang="ts">
-import {Component, toNative, Vue} from 'vue-facing-decorator'
+<script setup lang="ts">
 import {BASE_URL} from '@/lib/lib.ts'
 
-@Component
-class PrivacyPolicy extends Vue {
-  public logo = new URL('/static/images/logo.svg', BASE_URL).href
-}
-
-export default toNative(PrivacyPolicy)
+const logo = new URL('/static/images/logo.svg', BASE_URL).href
 </script>
 
 <style scoped>

--- a/frontend/components/views/legal/RefundPolicy.vue
+++ b/frontend/components/views/legal/RefundPolicy.vue
@@ -84,16 +84,10 @@
   </v-container>
 </template>
 
-<script lang="ts">
-import {Component, toNative, Vue} from 'vue-facing-decorator'
+<script setup lang="ts">
 import {BASE_URL} from '@/lib/lib.ts'
 
-@Component
-class RefundPolicy extends Vue {
-  public logo = new URL('/static/images/logo.svg', BASE_URL).href
-}
-
-export default toNative(RefundPolicy)
+const logo = new URL('/static/images/logo.svg', BASE_URL).href
 </script>
 
 <style scoped>

--- a/frontend/components/views/legal/TermsOfService.vue
+++ b/frontend/components/views/legal/TermsOfService.vue
@@ -11,7 +11,7 @@
         </div>
       </v-col>
       <v-col cols="12">
-        <p><strong>Last updated: April 1, 2023</strong></p>
+        <p><strong>Last updated: March 29, 2024</strong></p>
 
         <p>Please read these Terms of Service ("Terms", "Terms of Service") carefully before using
           the https://artconomy.com/ website (the "Service") operated by
@@ -120,6 +120,18 @@
           subscription.
         </p>
 
+        <h3>Auctions</h3>
+
+        <p>Artconomy may provide auction listings. If you bid in an auction, you commit to purchasing the offered
+          product or service from the seller at the bid price. Sellers commit to sell at the bid price, so long as any
+          pre-specified reserve price has been met.</p>
+
+        <p>Failure to honor these commitments can result in disciplinary action including suspension or removal of
+          your account.</p>
+
+        <p>Attempts to manipulate bid pricing, even unsuccessful attempts, may also result in similar disciplinary
+          action, and potential referral to law enforcement.</p>
+
         <p>Refunds are covered by our
           <router-link :to="{name: 'RefundPolicy'}">Refund Policy.</router-link>
         </p>
@@ -226,11 +238,6 @@
           known of the controversy, claim, dispute or breach.
         </p>
         <p>
-          Prevailing party means the party in whose favor final judgment after appeal (if any) is rendered with
-          respect to the claims asserted in the Complaint. "Reasonable attorneys' fees" are those reasonable attorneys'
-          fees actually incurred in obtaining a judgment in favor of the prevailing party.
-        </p>
-        <p>
           The prevailing party will be entitled to Reasonable attorneys' fees.
         </p>
         <h2>Contact Us</h2>
@@ -240,16 +247,10 @@
   </v-container>
 </template>
 
-<script lang="ts">
-import {Component, toNative, Vue} from 'vue-facing-decorator'
+<script setup lang="ts">
 import {BASE_URL} from '@/lib/lib.ts'
 
-@Component
-class TermsOfService extends Vue {
-  public logo = new URL('/static/images/logo.svg', BASE_URL).href
-}
-
-export default toNative(TermsOfService)
+const logo = new URL('/static/images/logo.svg', BASE_URL).href
 </script>
 
 <style scoped>


### PR DESCRIPTION
This update covers a few items:

* Add some wording for Auctions, as we'd like to start adding them soon.
* Clarify rights assignment in the case that legal regimes (such as Germany) may not recognize rights assignment as traditionally thought about in the US.
* Remove our unique definition of prevailing party to use the legal default in the case of arbitration. Also remove our definition of 'Reasonable Attorney's fees', deferring to the arbitrator's decision on that matter.

This also contains some small code changes to the legal page components that don't affect their content.